### PR TITLE
Fix to remove unexpected `.` in package fmt scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:eslint": "eslint --ext .ts,.tsx ./src",
     "lint:tsc": "tsc",
     "lint": "run-p lint:**",
-    "fmt": "eslint --ext .ts,.tsx --fix . ./src"
+    "fmt": "eslint --ext .ts,.tsx --fix ./src"
   },
   "inline": true,
   "devDependencies": {


### PR DESCRIPTION
Close #205 